### PR TITLE
Use __info__(:functions) instead of :exports

### DIFF
--- a/lib/decorators/decorate.ex
+++ b/lib/decorators/decorate.ex
@@ -102,7 +102,7 @@ defmodule Decorator.Decorate do
     [do: apply_decorator(context, mfa, body), rescue: apply_decorator_to_rescue(context, mfa, rescue_block)]
   end
   defp apply_decorator(context, {module, fun, args}, body) do
-    if Enum.member?(module.__info__(:exports), {fun, Enum.count(args) + 2}) do
+    if Enum.member?(module.__info__(:functions), {fun, Enum.count(args) + 2}) do
       Kernel.apply(module, fun, (args || []) ++ [body, context])
     else
       raise ArgumentError, "Unknown decorator function: #{fun}/#{Enum.count(args)}"


### PR DESCRIPTION
As reported in https://github.com/appsignal/appsignal-elixir/issues/268#issuecomment-346570356. 

Since
https://github.com/elixir-lang/elixir/commit/5ed491a7ea8962310a5a5763bf358d42db58a421,
`Module.__info__/1` doesn't drop down to `:erlang.module_info/1`
anymore. This patch switches to using Elixir's `:functions` instead of
Erlang's `:exports`. Both return exported functions, but the former
doesn't include `__info__/1`, `module_info/0`, and `module_info/1`,
which aren't needed for our purposes.