### PR TITLE
Add a `@decorate_all` attribute which decorates every function in mod

### DIFF
--- a/lib/decorators/define.ex
+++ b/lib/decorators/define.ex
@@ -36,6 +36,7 @@ defmodule Decorator.Define do
 
           Module.register_attribute __MODULE__, :decorate, accumulate: true
           Module.register_attribute __MODULE__, :decorated, accumulate: true
+          Module.register_attribute __MODULE__, :decorate_all, accumulate: true
 
           @on_definition {Decorator.Decorate, :on_definition}
           @before_compile {Decorator.Decorate, :before_compile}

--- a/test/decorate_all_test.exs
+++ b/test/decorate_all_test.exs
@@ -1,0 +1,60 @@
+defmodule DecoratorTest.Fixture.DecorateAllDecorator do
+  use Decorator.Define, [some_decorator: 1]
+
+  def some_decorator(message, body, _context) do
+    quote do
+      send self(), unquote(message)
+      unquote(body)
+    end
+  end
+end
+
+defmodule DecoratorTest.Fixture.DecorateAllTestModule do
+  use DecoratorTest.Fixture.DecorateAllDecorator
+
+  @decorate_all some_decorator(:we_did_it)
+
+  def fun_one do
+    :ok
+  end
+
+  def fun_two do
+    :ok
+  end
+
+  def fun_two(_arg1, something \\ :default)
+  def fun_two(_arg1, something) do
+    something
+  end
+
+  def fun_three("test_one") do
+    :ok
+  end
+
+  def fun_three("test_two") do
+    :ok
+  end
+end
+
+defmodule DecorateAllTest do
+  use ExUnit.Case
+
+  alias DecoratorTest.Fixture.DecorateAllTestModule
+
+  test "@decorate_all decorates all functions" do
+    DecorateAllTestModule.fun_one()
+    assert_received :we_did_it
+
+    DecorateAllTestModule.fun_two()
+    assert_received :we_did_it
+
+    DecorateAllTestModule.fun_two("test_one")
+    assert_received :we_did_it
+
+    DecorateAllTestModule.fun_three("test_one")
+    assert_received :we_did_it
+
+    DecorateAllTestModule.fun_three("test_two")
+    assert_received :we_did_it
+  end
+end


### PR DESCRIPTION
Solves two problems for me:

- Decorating every function in a module
- Decorating functions with the same name but different arities with defaults caused compilation errors