### PR TITLE
Fix attribute value usage

### DIFF
--- a/test/basic_test.exs
+++ b/test/basic_test.exs
@@ -18,10 +18,14 @@ defmodule DecoratorTest.Fixture.MyModule do
   def answer, do: 24
 
   @value 123
+  @decorate some_decorator()
   def value123, do: @value
 
   @value 666
-  def value666, do: @value
+  @decorate some_decorator()
+  def value666 do
+    {:ok, 2 * (@value / 2)}
+  end
 end
 
 defmodule DecoratorTest.Basic do
@@ -39,6 +43,6 @@ defmodule DecoratorTest.Basic do
 
   test "normal module attributes should still work" do
     assert 123 == MyModule.value123()
-    assert 666 == MyModule.value666()
+    assert {:ok, 666} == MyModule.value666()
   end
 end

--- a/test/basic_test.exs
+++ b/test/basic_test.exs
@@ -24,7 +24,7 @@ defmodule DecoratorTest.Fixture.MyModule do
   @value 666
   @decorate some_decorator()
   def value666 do
-    {:ok, 2 * (@value / 2)}
+    {:ok, trunc(2 * @value * 0.5)}
   end
 end
 


### PR DESCRIPTION
When using attributes inside decorated functions, and the attribute is redefined later on, the last known value is used when the decorated function is redefined, instead of the value that the attribute had on the position of the original definition of the function.