### PR TITLE
Decorate function with empty body

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: elixir
 matrix:
   include:
-    - name: "Elixir 1.3 / OTP 18"
-      elixir: 1.3
+    - name: "Elixir 1.5 / OTP 18"
+      elixir: 1.5
       otp_release: 18.3
     - name: "Elixir 1.6 / OTP 20"
       elixir: 1.6

--- a/lib/decorators/decorate.ex
+++ b/lib/decorators/decorate.ex
@@ -34,6 +34,7 @@ defmodule Decorator.Decorate do
 
     decorated
     |> filter_undecorated(decorated_functions)
+    |> reject_empty_clauses()
     |> Enum.reduce({nil, []}, fn d, acc ->
       decorate(env, d, decorated_functions, acc)
     end)
@@ -64,6 +65,10 @@ defmodule Decorator.Decorate do
       Map.has_key?(decorated_functions, {fun, Enum.count(args)})
     end)
   end
+
+ defp reject_empty_clauses(all) do
+   Enum.reject(all, fn {_kind, _fun, _args, _guards, body, _decorators, _attrs} -> body == nil end)
+ end
 
   defp implied_arities(args) do
     arity = Enum.count(args)

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Decorator.Mixfile do
     [
       app: :decorator,
       version: File.read!("VERSION"),
-      elixir: "~> 1.3",
+      elixir: "~> 1.5",
       elixirc_options: [warnings_as_errors: true],
       description: description(),
       package: package(),

--- a/test/decorate_all_test.exs
+++ b/test/decorate_all_test.exs
@@ -20,6 +20,12 @@ defmodule DecoratorDecorateAllTest.Fixture.MyModule do
   def value123, do: 123
 
   def value666, do: 666
+
+
+  def empty_body(a)
+
+  def empty_body(10), do: 11
+  def empty_body(n), do: n+2
 end
 
 defmodule DecoratorDecorateAllTest do
@@ -32,5 +38,7 @@ defmodule DecoratorDecorateAllTest do
     assert {:ok, 24} == MyModule.answer()
     assert {:ok, 123} == MyModule.value123()
     assert {:ok, 666} == MyModule.value666()
+    assert {:ok, 11} == MyModule.empty_body(10)
+    assert {:ok, 8} == MyModule.empty_body(6)
   end
 end

--- a/test/function_decorator_test.exs
+++ b/test/function_decorator_test.exs
@@ -63,6 +63,16 @@ defmodule DecoratorTest.Fixture.PrivateDecorated do
   defp foo(x), do: x
 end
 
+defmodule DecoratorTest.Fixture.DecoratedFunctionWithEmptyClause do
+  use DecoratorTest.Fixture.FunctionResultDecorator
+
+   @decorate function_result(:ok)
+  def multiply(x, y \\ 1)
+
+  def multiply(1, y) do y end
+  def multiply(x, y) do x * y end
+ end
+
 # Tests itself
 defmodule DecoratorTest.FunctionDecorator do
   use ExUnit.Case
@@ -71,6 +81,7 @@ defmodule DecoratorTest.FunctionDecorator do
     MyFunctionResultModule,
     DecoratedFunctionClauses,
     DecoratedFunctionWithDifferentArities,
+    DecoratedFunctionWithEmptyClause,
     FunctionResultDecorator,
     PrivateDecorated
   }
@@ -89,6 +100,12 @@ defmodule DecoratorTest.FunctionDecorator do
   test "decorating a function with different arity heads" do
     assert {:ok, 3} == DecoratedFunctionWithDifferentArities.testfun(1, 2)
     assert {:ok, 5} == DecoratedFunctionWithDifferentArities.testfun(5)
+  end
+
+ test "decorating a function with an empty clause" do
+    assert {:ok, 11} == DecoratedFunctionWithEmptyClause.multiply(11)
+    assert {:ok, 24} == DecoratedFunctionWithEmptyClause.multiply(6,4)
+    assert {:ok, 5} == DecoratedFunctionWithEmptyClause.multiply(1,5)
   end
 
   test "should throw error when defining an unknown decorator" do


### PR DESCRIPTION
This PR address: https://github.com/arjan/decorator/issues/18

Notes:
- you can decorate functions that have empty bodies (e.g used for defining default args)
- works with `@decorate_all` attribute