### PR TITLE
Decorate_all with custom attribute

### DIFF
--- a/lib/decorators/decorate.ex
+++ b/lib/decorators/decorate.ex
@@ -66,9 +66,11 @@ defmodule Decorator.Decorate do
     end)
   end
 
- defp reject_empty_clauses(all) do
-   Enum.reject(all, fn {_kind, _fun, _args, _guards, body, _decorators, _attrs} -> body == nil end)
- end
+  defp reject_empty_clauses(all) do
+    Enum.reject(all, fn {_kind, _fun, _args, _guards, body, _decorators, _attrs} ->
+      body == nil
+    end)
+  end
 
   defp implied_arities(args) do
     arity = Enum.count(args)
@@ -101,7 +103,7 @@ defmodule Decorator.Decorate do
     attrs =
       attrs
       |> Enum.map(fn {attr, value} ->
-        {:@, [], [{attr, [], [value]}]}
+        {:@, [], [{attr, [], [Macro.escape(value)]}]}
       end)
 
     arity = Enum.count(args || [])

--- a/test/decorate_all_test.exs
+++ b/test/decorate_all_test.exs
@@ -26,11 +26,28 @@ defmodule DecoratorDecorateAllTest.Fixture.MyModule do
 
   def empty_body(10), do: 11
   def empty_body(n), do: n+2
+
+end
+
+defmodule DecoratorDecorateAllTest.Fixture.MyModuleWithAttribute do
+  use DecoratorDecorateAllTest.Fixture.MyDecorator
+
+  @decorate_all some_decorator()
+
+  @custom_attr 15
+  @custom_attr_map %{some_val: 3, other_val: 10}
+
+  def fun1(x), do: x+2
+
+  def fun2(x), do: x + @custom_attr
+
+  def fun3(x), do: x + @custom_attr_map[:some_val]
 end
 
 defmodule DecoratorDecorateAllTest do
   use ExUnit.Case
   alias DecoratorDecorateAllTest.Fixture.MyModule
+  alias DecoratorDecorateAllTest.Fixture.MyModuleWithAttribute
 
   test "decorate_all" do
     assert {:ok, 4} == MyModule.square(2)
@@ -40,5 +57,8 @@ defmodule DecoratorDecorateAllTest do
     assert {:ok, 666} == MyModule.value666()
     assert {:ok, 11} == MyModule.empty_body(10)
     assert {:ok, 8} == MyModule.empty_body(6)
+    assert {:ok, 10} == MyModuleWithAttribute.fun1(8)
+    assert {:ok, 20} == MyModuleWithAttribute.fun2(5)
+    assert {:ok, 8} == MyModuleWithAttribute.fun3(5)
   end
 end


### PR DESCRIPTION
If you use some custom attributes together with `decorate_all`, it is not compiling.
In this PR just simple test