### PR TITLE
Add an attribute to module to check if it has already been decorated

### DIFF
--- a/lib/decorators/define.ex
+++ b/lib/decorators/define.ex
@@ -34,12 +34,17 @@ defmodule Decorator.Define do
         quote do
           import unquote(@decorator_module), only: unquote(imports)
 
-          Module.register_attribute(__MODULE__, :decorate_all, accumulate: true)
-          Module.register_attribute(__MODULE__, :decorate, accumulate: true)
-          Module.register_attribute(__MODULE__, :decorated, accumulate: true)
+          if is_nil(Module.get_attribute(__MODULE__, :has_been_decorated)) do
+            Module.register_attribute(__MODULE__, :has_been_decorated, accumulate: false)
+            Module.put_attribute(__MODULE__, :has_been_decorated, true)
 
-          @on_definition {Decorator.Decorate, :on_definition}
-          @before_compile {Decorator.Decorate, :before_compile}
+            Module.register_attribute(__MODULE__, :decorate_all, accumulate: true)
+            Module.register_attribute(__MODULE__, :decorate, accumulate: true)
+            Module.register_attribute(__MODULE__, :decorated, accumulate: true)
+
+            @on_definition {Decorator.Decorate, :on_definition}
+            @before_compile {Decorator.Decorate, :before_compile}
+          end
         end
       end
     end

--- a/test/multiple_decorator_modules_used_in_one_module.exs
+++ b/test/multiple_decorator_modules_used_in_one_module.exs
@@ -1,0 +1,36 @@
+defmodule DecoratorTest.Fixture.MonitoringDecorator do
+  use Decorator.Define, some_decorator: 0
+
+  def some_decorator(body, _context) do
+    {:ok, body}
+  end
+end
+
+defmodule DecoratorTest.Fixture.LoggingDecorator do
+  use Decorator.Define, test_log: 0
+
+  def test_log(body, _context) do
+    {:ok, body}
+  end
+end
+
+
+defmodule DecoratorTest.Fixture.TwoDecoratorsUsed do
+  use DecoratorTest.Fixture.LoggingDecorator
+  use DecoratorTest.Fixture.MonitoringDecorator
+
+  @decorate some_decorator()
+  def result(default \\ nil) do
+    default
+  end
+end
+
+defmodule DecoratorTest.MultipleDecoratorModules do
+  use ExUnit.Case
+  alias DecoratorTest.Fixture.TwoDecoratorsUsed
+
+  test "module compiles and is not redefined" do
+    assert {:ok, "tested"} == TwoDecoratorsUsed.result("tested")
+    assert {:ok, nil} == TwoDecoratorsUsed.result()
+  end
+end


### PR DESCRIPTION
Prevent separate decorators from calling on_definition each time, which causes duplicate function definitions and throws warnings of previous definitions. This problem also prevents two separate decorator modules from being included if any function in the module has a default value

The unit test will fail to compile without the included changes

Resolves https://github.com/arjan/decorator/issues/33

