### PR TITLE
Human copyable format

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ Add `decorator` to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
-  [{:decorator, "~> 1.2"}]
+  [
+    {:decorator, "~> 1.2"}
+  ]
 end
 ```
 


### PR DESCRIPTION
The previous version of formatting causes difficulties when trying to copy a line with a double click.
After inserting into the code, you have to delete parentheses.
In my opinion, this formatting option is more convenient and adapted for copy paste.