### PR TITLE
Fix for @decorate_all when function clauses are separated.

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Decorator.Mixfile do
       app: :decorator,
       version: File.read!("VERSION"),
       elixir: "~> 1.5",
-      elixirc_options: [warnings_as_errors: true],
+      elixirc_options: elixirrc_options(Mix.env()),
       description: description(),
       package: package(),
       source_url: "https://github.com/arjan/decorator",
@@ -33,6 +33,14 @@ defmodule Decorator.Mixfile do
 
   def application do
     [applications: [:logger]]
+  end
+
+  defp elixirrc_options(:test) do
+    []
+  end
+
+  defp elixirrc_options(_) do
+    [warnings_as_errors: true]
   end
 
   defp docs do

--- a/test/decorate_all_test.exs
+++ b/test/decorate_all_test.exs
@@ -44,10 +44,23 @@ defmodule DecoratorDecorateAllTest.Fixture.MyModuleWithAttribute do
   def fun3(x), do: x + @custom_attr_map[:some_val]
 end
 
+defmodule DecoratorDecorateAllTest.Fixture.MyModuleWithSeparatedClauses do
+  use DecoratorDecorateAllTest.Fixture.MyDecorator
+
+  @decorate_all some_decorator()
+
+  def fun1(0), do: :zero
+
+  def fun2(x), do: x + 2
+
+  def fun1(x), do: x
+end
+
 defmodule DecoratorDecorateAllTest do
   use ExUnit.Case
   alias DecoratorDecorateAllTest.Fixture.MyModule
   alias DecoratorDecorateAllTest.Fixture.MyModuleWithAttribute
+  alias DecoratorDecorateAllTest.Fixture.MyModuleWithSeparatedClauses
 
   test "decorate_all" do
     assert {:ok, 4} == MyModule.square(2)
@@ -60,5 +73,8 @@ defmodule DecoratorDecorateAllTest do
     assert {:ok, 10} == MyModuleWithAttribute.fun1(8)
     assert {:ok, 20} == MyModuleWithAttribute.fun2(5)
     assert {:ok, 8} == MyModuleWithAttribute.fun3(5)
+    assert {:ok, :zero} == MyModuleWithSeparatedClauses.fun1(0)
+    assert {:ok, 4} == MyModuleWithSeparatedClauses.fun2(2)
+    assert {:ok, 2} == MyModuleWithSeparatedClauses.fun1(2)
   end
 end


### PR DESCRIPTION
Previously, when using `@decorate_all`, if you had defined a function that
had multiple clauses, but the clauses weren't next to each other, we
would only redefine the second clause, thus the first clause would be
entirely lost.

I realise it's bad practice to have clauses not next to each other, but
the failure mode was very confusing. It would give a
`FunctionClauseError` saying the function clause couldn't match. But
upon looking in the source code, that clause was clearly there.

I've fixed this by checking for all previous definitions when deciding
whether to output the overridable clause.

I've added a test to show the problem. If you run that on the previous
code it will fail because the first clause is ommitted.

## Thanks

By the way thanks for all your hard work, the library is really useful!