### PR TITLE
Update decorate.ex

### DIFF
--- a/lib/decorator/decorate.ex
+++ b/lib/decorator/decorate.ex
@@ -146,8 +146,6 @@ defmodule Decorator.Decorate do
           end
       end
 
-    arity = Enum.count(args)
-
     fun_and_arity = {fun, arity}
 
     if not Enum.member?(prev_funs, fun_and_arity) do


### PR DESCRIPTION
Remove second definition of `arity` because it's already bound on line 116