### PR TITLE
docs: improve decorate_all documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,9 @@ end
 
 ### Decorating all functions in a module
 
-A shortcut to decorate all functions in a module is to use the `@decorate_all` attribute:
+A shortcut to decorate all functions in a module is to use the `@decorate_all` attribute, as shown below. It is
+important to note that the `@decorate_all` attribute only
+affects the function clauses below its definition.
 
 ```elixir
 defmodule MyApp.APIController


### PR DESCRIPTION
I noticed that the `@decorate_all` attribute behaves in an unexpected way when it is defined in the middle of the file, so this PR aims to make the docs more clear.

Also, there is some erratic behavior when the `@decorate` attribute is defined on one of the `do`-clauses of a multi-clause function. Any suggestions on how to make the doc more clear on this?