### PR TITLE
Support `catch` as part of `do`-block

### DIFF
--- a/lib/decorator/decorate.ex
+++ b/lib/decorator/decorate.ex
@@ -167,7 +167,22 @@ defmodule Decorator.Decorate do
   defp apply_decorator(context, mfa, do: body, rescue: rescue_block) do
     [
       do: apply_decorator(context, mfa, body),
-      rescue: apply_decorator_to_rescue(context, mfa, rescue_block)
+      rescue: apply_decorator_to_wrapped_try(context, mfa, rescue_block)
+    ]
+  end
+
+  defp apply_decorator(context, mfa, do: body, rescue: rescue_block, catch: catch_block) do
+    [
+      do: apply_decorator(context, mfa, body),
+      rescue: apply_decorator_to_wrapped_try(context, mfa, rescue_block),
+      catch: apply_decorator_to_wrapped_try(context, mfa, catch_block)
+    ]
+  end
+
+  defp apply_decorator(context, mfa, do: body, catch: catch_block) do
+    [
+      do: apply_decorator(context, mfa, body),
+      catch: apply_decorator_to_wrapped_try(context, mfa, catch_block)
     ]
   end
 
@@ -183,8 +198,8 @@ defmodule Decorator.Decorate do
     raise ArgumentError, "Invalid decorator: #{inspect(decorator)}"
   end
 
-  defp apply_decorator_to_rescue(context, mfa, rescue_block) do
-    rescue_block
+  defp apply_decorator_to_wrapped_try(context, mfa, wrapped_block) do
+    wrapped_block
     |> Enum.map(fn {:->, meta, [match, body]} ->
       {:->, meta, [match, apply_decorator(context, mfa, body)]}
     end)

--- a/test/exception_test.exs
+++ b/test/exception_test.exs
@@ -11,15 +11,38 @@ defmodule DecoratorTest.Fixture.ExceptionTestModule do
   use DecoratorTest.Fixture.ExceptionDecorator
 
   @decorate test()
-  def result(a) do
-    if a == :throw do
+  def rescued(a) do
+    if a == :raise do
       raise RuntimeError, "text"
     end
 
     a
   rescue
-    _ in RuntimeError ->
-      :error
+    _ in RuntimeError -> :error
+  end
+
+  @decorate test()
+  def catched(a) do
+    if a == :throw do
+      throw(a)
+    end
+
+    a
+  catch
+    _ -> :thrown
+  end
+
+  @decorate test()
+  def rescued_and_catched(a) do
+    case a do
+      :throw -> throw(a)
+      :raise -> raise RuntimeError, "text"
+      a -> a
+    end
+  rescue
+    _ in RuntimeError -> :error
+  catch
+    _ -> :thrown
   end
 end
 
@@ -29,7 +52,18 @@ defmodule DecoratorTest.Exception do
   alias DecoratorTest.Fixture.ExceptionTestModule
 
   test "Functions which have a 'rescue' clause" do
-    assert {:ok, 3} = ExceptionTestModule.result(3)
-    assert {:ok, :error} = ExceptionTestModule.result(:throw)
+    assert {:ok, 3} = ExceptionTestModule.rescued(3)
+    assert {:ok, :error} = ExceptionTestModule.rescued(:raise)
+  end
+
+  test "Functions which have a 'catch' clause" do
+    assert {:ok, 3} = ExceptionTestModule.catched(3)
+    assert {:ok, :thrown} = ExceptionTestModule.catched(:throw)
+  end
+
+  test "Functions which have a 'rescue' and a 'catch' clause" do
+    assert {:ok, 3} = ExceptionTestModule.rescued_and_catched(3)
+    assert {:ok, :thrown} = ExceptionTestModule.rescued_and_catched(:throw)
+    assert {:ok, :error} = ExceptionTestModule.rescued_and_catched(:raise)
   end
 end


### PR DESCRIPTION
Elixir automatically wraps the body of `do` in a `try`-block when one of the keywords `rescue` or `catch` is specified. They can also be used in conjunction with eachother.

This solves the following compilation error:
```
== Compilation error in file test/exception_test.exs ==
** (CompileError) test/exception_test.exs:32: unhandled operator ->
    (stdlib 3.13.2) lists.erl:1358: :lists.mapfoldl/3
    (stdlib 3.13.2) lists.erl:1359: :lists.mapfoldl/3
    (stdlib 3.13.2) lists.erl:1358: :lists.mapfoldl/3
    (stdlib 3.13.2) lists.erl:1359: :lists.mapfoldl/3
```

I chose the simplest and most straightforward solution by duplicating a bit of code. I think it's easier to maintain than a loop or reducer. Especially since the keywords are limited and should appear in a specific order:

```
warning: "catch" should always come after "rescue" in def
  test/exception_test.exs:36
```