### PR TITLE
Expose function kind in Context

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,14 +173,14 @@ end
 
 Besides the function body AST, the decorator function also gets a
 *context* argument passed in. This context holds information about the
-function being decorated, namely its module, function name, arity, and
-arguments as a list of AST nodes.
+function being decorated, namely its module, function name, arity, function
+kind, and arguments as a list of AST nodes.
 
 The print decorator can print its function name like this:
 
 ```elixir
 def print(body, context) do
-  Logger.debug("Function #{context.name}/#{context.arity} called in module #{context.module}!")
+  Logger.debug("Function #{context.name}/#{context.arity} with kind #{context.kind} called in module #{context.module}!")
 end
 ```
 

--- a/lib/decorator/decorate.ex
+++ b/lib/decorator/decorate.ex
@@ -6,7 +6,7 @@ defmodule Decorator.Decorate do
     Struct with information about the function that is being decorated.
     """
 
-    defstruct name: nil, arity: nil, module: nil, args: nil
+    defstruct name: nil, arity: nil, module: nil, args: nil, kind: nil
   end
 
   def on_definition(env, kind, fun, args, guards, body) do
@@ -114,7 +114,7 @@ defmodule Decorator.Decorate do
       end)
 
     arity = Enum.count(args || [])
-    context = %Context{name: fun, arity: arity, args: args, module: env.module}
+    context = %Context{name: fun, arity: arity, args: args, module: env.module, kind: kind}
 
     applicable_decorators =
       case decorators do

--- a/test/context_test.exs
+++ b/test/context_test.exs
@@ -1,0 +1,48 @@
+defmodule DecoratorTest.Fixture.ContextDecorator do
+  use Decorator.Define, expose: 0
+  alias Decorator.Decorate.Context
+
+  def expose(body, %Context{arity: arity, module: module, name: name, kind: kind}) do
+    quote do
+      {%{
+         arity: unquote(arity),
+         module: unquote(module),
+         name: unquote(name),
+         kind: unquote(kind)
+       }, unquote(body)}
+    end
+  end
+end
+
+defmodule DecoratorTest.Fixture.ContextModule do
+  use DecoratorTest.Fixture.ContextDecorator
+
+  @decorate expose()
+  def result(a) do
+    a
+  end
+
+  def public_sum(a, b) do
+    private_sum(a, b)
+  end
+
+  @decorate expose()
+  defp private_sum(a, b) do
+    a + b
+  end
+end
+
+defmodule DecoratorTest.Context do
+  use ExUnit.Case, async: true
+  alias DecoratorTest.Fixture.ContextModule
+
+  test "exposes public function context" do
+    assert {context, 3} = ContextModule.result(3)
+    assert context == %{arity: 1, kind: :def, module: ContextModule, name: :result}
+  end
+
+  test "exposes private function context" do
+    assert {context, 3} = ContextModule.public_sum(1, 2)
+    assert context == %{arity: 2, kind: :defp, module: ContextModule, name: :private_sum}
+  end
+end


### PR DESCRIPTION
Hey folks! 

I have a scenario where I want my decorator behavior to be conditioned by the function kind - whether public or private.

So I opened this PR to expose the function kind 😄. What this PR does is:
- Exposes the _function kind_ in `%Decorator.Decorate.Context{}`
- Adds a simple test to the test suit that asserts context is being exposed correctly
