### PR TITLE
Group functions by arity

### DIFF
--- a/test/decorate_all_test.exs
+++ b/test/decorate_all_test.exs
@@ -48,10 +48,9 @@ defmodule DecoratorDecorateAllTest.Fixture.MyModuleWithSeparatedClauses do
   @decorate_all some_decorator()
 
   def fun1(0), do: :zero
+  def fun1(x), do: x
 
   def fun2(x), do: x + 2
-
-  def fun1(x), do: x
 end
 
 defmodule DecoratorDecorateAllTest do


### PR DESCRIPTION
This fixed warning below:

warning: clauses with the same name and arity (number of arguments) should be grouped together, "def fun1/1" was previously defined (test/decorate_all_test.exs:50)
  test/decorate_all_test.exs:54