### PR TITLE
Added a "reflection" function `__decorated_functions__`

### DIFF
--- a/lib/decorator/define.ex
+++ b/lib/decorator/define.ex
@@ -43,9 +43,11 @@ defmodule Decorator.Define do
             Module.register_attribute(__MODULE__, :decorate_all, accumulate: true)
             Module.register_attribute(__MODULE__, :decorate, accumulate: true)
             Module.register_attribute(__MODULE__, :decorated, accumulate: true)
+            Module.register_attribute(__MODULE__, :decorated_functions, accumulate: true)
 
             @on_definition {Decorator.Decorate, :on_definition}
             @before_compile {Decorator.Decorate, :before_compile}
+            @before_compile {Decorator.Decorate, :add_decorated_functions}
           end
         end
       end

--- a/test/decorated_functions_test.exs
+++ b/test/decorated_functions_test.exs
@@ -1,0 +1,45 @@
+defmodule DecoratorTest.Fixture.NewDecorator do
+  use Decorator.Define, new_decorator: 1
+
+  def new_decorator(_arg, body, _context), do: body
+end
+
+defmodule DecoratorTest.Fixture.AnotherDecorator do
+  use Decorator.Define, another_decorator: 2
+
+  def another_decorator(_arg1, _arg2, body, _context), do: body
+end
+
+defmodule StructOne, do: defstruct([:a, :b])
+defmodule StructTwo, do: defstruct([:c, :d])
+
+defmodule DecoratorTest.Fixture.NewModule do
+  use DecoratorTest.Fixture.NewDecorator
+  use DecoratorTest.Fixture.AnotherDecorator
+
+  @decorate new_decorator("one")
+  def func(%StructOne{} = msg), do: msg.a
+
+  @decorate new_decorator("two")
+  @decorate another_decorator("a", "b")
+  @decorate new_decorator("b")
+  def func(%StructTwo{c: 2} = _msg), do: :ok
+end
+
+defmodule DecoratorTest.MyTest do
+  use ExUnit.Case
+  alias DecoratorTest.Fixture.NewModule
+
+  test "Module with decorated functions are returned by `__decorated_functions__()" do
+    assert %{
+             {:func, ["%StructOne{} = msg"]} => [
+               {DecoratorTest.Fixture.NewDecorator, :new_decorator, ["one"]}
+             ],
+             {:func, ["%StructTwo{c: 2} = _msg"]} => [
+               {DecoratorTest.Fixture.NewDecorator, :new_decorator, ["two"]},
+               {DecoratorTest.Fixture.AnotherDecorator, :another_decorator, ["a", "b"]},
+               {DecoratorTest.Fixture.NewDecorator, :new_decorator, ["b"]}
+             ]
+           } == NewModule.__decorated_functions__()
+  end
+end


### PR DESCRIPTION
Added a "reflection" function `__decorated_functions__` to return list of all decorated functions

### Simple reflection for all decorated functions
A "hidden" function `__decorated_functions__/0` is added to any module that decorates functions and returns a list of all decorated functions within that module.

This can be useful for testing purposes since you don't have to assert the decorated behaviors of the decorated functions.  So long as your decorator function is well tested, you can just assert the expected decorators are present for the given function.

The function returns a map with the function name and arguments as the key and a list of tuples with the decorator. This permits multiple decorators to be asserted with a single function call so that adding new decorators will cause the assertion to fail.

For example, given the following module:
```elixir
  defmodule NewModule do
    use Decorator.Define, [new_decorator: 1, another_decorator: 2]

    @decorate new_decorator("one")
    def func(%StructOne{} = msg) do
      msg
    end

    @decorate new_decorator("two")
    @decorate another_decorator("a", "b")
    @decorate new_decorator("b")
    def func(%StructTwo{c: 2} = _msg) do
      :ok
    end
  end
```

You can assert the decorated functions like so:
```elixir
  test "Module with decorated functions are returned by `__decorated_functions__()" do
    assert %{
             {:func, ["%StructOne{} = msg"]} => [
               {DecoratorTest.Fixture.NewDecorator, :new_decorator, ["one"]}
             ],
             {:func, ["%StructTwo{c: 2} = _msg"]} => [
               {DecoratorTest.Fixture.NewDecorator, :new_decorator, ["two"]},
               {DecoratorTest.Fixture.AnotherDecorator, :another_decorator, ["a", "b"]},
               {DecoratorTest.Fixture.NewDecorator, :new_decorator, ["b"]}
             ]
           } == NewModule.__decorated_functions__()
  end
```

Obviously, any changes to the parameters of the decorated function will cause the simple assertion to fail, but that's intentional, as the decorator may be dependent on the parameters of the decorated function.