### PR TITLE
rename decorated attribute to avoid naming collisions

### DIFF
--- a/lib/decorator/decorate.ex
+++ b/lib/decorator/decorate.ex
@@ -17,7 +17,7 @@ defmodule Decorator.Decorate do
     attrs = extract_attributes(env.module, body)
     decorated = {kind, fun, args, guards, body, decorators, attrs}
 
-    Module.put_attribute(env.module, :decorated, decorated)
+    Module.put_attribute(env.module, :decorator_decorated, decorated)
     Module.delete_attribute(env.module, :decorate)
   end
 
@@ -34,8 +34,8 @@ defmodule Decorator.Decorate do
   end
 
   defmacro before_compile(env) do
-    decorated = Module.get_attribute(env.module, :decorated) |> Enum.reverse()
-    Module.delete_attribute(env.module, :decorated)
+    decorated = Module.get_attribute(env.module, :decorator_decorated) |> Enum.reverse()
+    Module.delete_attribute(env.module, :decorator_decorated)
 
     decorated_functions = decorated_functions(decorated)
 

--- a/lib/decorator/define.ex
+++ b/lib/decorator/define.ex
@@ -42,7 +42,7 @@ defmodule Decorator.Define do
 
             Module.register_attribute(__MODULE__, :decorate_all, accumulate: true)
             Module.register_attribute(__MODULE__, :decorate, accumulate: true)
-            Module.register_attribute(__MODULE__, :decorated, accumulate: true)
+            Module.register_attribute(__MODULE__, :decorator_decorated, accumulate: true)
 
             @on_definition {Decorator.Decorate, :on_definition}
             @before_compile {Decorator.Decorate, :before_compile}


### PR DESCRIPTION
Oban.Pro.Decorator is using `decorated` as a module attribute which is conflicting with this library and causing neither decorator to function properly. Namespacing this attribute should fix this.